### PR TITLE
Fix missing splat operator on ´ read_multi´and refactor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,4 @@ source 'http://rubygems.org'
 gemspec
 
 gem 'minitest'
-gem 'wrong'
 gem 'rake'

--- a/lib/cacher.rb
+++ b/lib/cacher.rb
@@ -145,7 +145,9 @@ public
   end
 
   def get_multi(keys)
-    cached_results = cache.read_multi(keys.map { |k| prepare_key(k) }).inject({}) do |results, (key, value)|
+    prepared_keys = keys.map { |k| prepare_key(k) }
+    cached = cache.read_multi(*prepared_keys)
+    cached_results = cached.inject({}) do |results, (key, value)|
       results[key] = unmarshal_value(value)
       results
     end

--- a/spec/cacher_spec.rb
+++ b/spec/cacher_spec.rb
@@ -1,10 +1,10 @@
 describe Cacher do
   describe 'configuring' do
     it 'sets global configuration options' do
-      deny { Cacher::Base.new.namespaced? }
+      refute(Cacher::Base.new.namespaced?)
       Cacher.namespace = 'global'
-      assert { Cacher::Base.new.namespaced? }
-      assert { Cacher::Base.new.namespace == 'global' }
+      assert(Cacher::Base.new.namespaced?)
+      assert(Cacher::Base.new.namespace == 'global')
     end
 
     it 'yields a configure block' do
@@ -13,7 +13,7 @@ describe Cacher do
         config.cache = some_cache
       end
 
-      assert { Cacher.cache.object_id == some_cache.object_id }
+      assert(Cacher.cache.object_id == some_cache.object_id)
     end
 
     it 'yields a configure block on a new object' do
@@ -21,12 +21,12 @@ describe Cacher do
         cacher.max_key_size = 12
       end
 
-      assert { my_cacher.max_key_size == 12 }
+      assert(my_cacher.max_key_size == 12)
     end
 
     it 'creates a new object with a hash' do
       my_cacher = Cacher::Base.new(:enabled => true)
-      assert { my_cacher.enabled? }
+      assert(my_cacher.enabled?)
     end
   end
 
@@ -44,14 +44,14 @@ describe Cacher do
       end
 
       it 'sets and gets key' do
-        assert { cacher.get('foo').nil? }
-        assert { cacher.set('foo') { 'bar' } == 'bar' }
-        assert { cacher.get('foo') == 'bar' }
+        assert(cacher.get('foo').nil?)
+        assert(cacher.set('foo') { 'bar' } == 'bar')
+        assert(cacher.get('foo') == 'bar')
       end
 
       it 'gets with block syntax' do
-        assert { cacher.get('foo') { 1 } == 1 }
-        assert { cacher.get('foo') { 2 } == 1 }
+        assert(cacher.get('foo') { 1 } == 1)
+        assert(cacher.get('foo') { 2 } == 1)
       end
 
       it 'only calls the block once' do
@@ -61,33 +61,33 @@ describe Cacher do
           cacher.get('foo') { counter += 1 }
         end
 
-        assert { counter == 1 }
+        assert(counter == 1)
       end
 
       it 'queries a key with #key?' do
-        assert { cacher.key?('foo') == false }
+        assert(cacher.key?('foo') == false)
         cacher.set('foo') { 'bar' }
-        assert { cacher.key?('foo') == true }
+        assert(cacher.key?('foo') == true)
       end
 
       it 'transparently handles nil values' do
         cacher.set('foo') { nil }
-        assert { cacher.key?('foo') == true }
-        assert { cacher.get('foo') == nil }
-        assert { cacher.get('foo') { :not_nil } == nil }
+        assert(cacher.key?('foo') == true)
+        assert(cacher.get('foo') == nil)
+        assert(cacher.get('foo') { :not_nil } == nil)
       end
 
       it 'uses a namespace' do
         cacher.namespace = 'my_cool_namespace'
         cacher.set('foo') { 1 }
-        assert { cache.keys.include? 'my_cool_namespace/foo' }
-        deny   { cache.keys.include? 'foo' }
+        assert(cache.keys.include? 'my_cool_namespace/foo')
+        refute(cache.keys.include? 'foo')
       end
 
       it %[doesn't use a namespace by default] do
-        deny { cacher.namespaced? }
+        refute(cacher.namespaced?)
         cacher.set('foo') { 1 }
-        assert { cache.keys.include? 'foo' }
+        assert(cache.keys.include? 'foo')
       end
 
       it %[shortens a key if it's too long] do
@@ -95,8 +95,8 @@ describe Cacher do
         cacher.max_key_size = 100
 
         cacher.set(key) { 3 }
-        assert { cache.last_accessed_key =~ %r[^sha1/[0-9a-f]+$] }
-        assert { cacher.get(key) == 3 }
+        assert(cache.last_accessed_key =~ %r[^sha1/[0-9a-f]+$])
+        assert(cacher.get(key) == 3)
       end
 
       describe 'marshalling' do
@@ -107,19 +107,19 @@ describe Cacher do
         it 'adds /marshal to the end of the key' do
           cacher.set('foo') { 1 }
 
-          assert { cache.last_accessed_key == 'foo/marshal' }
+          assert(cache.last_accessed_key == 'foo/marshal')
         end
 
         it 'marshals the value' do
           cacher.set('foo') { 1 }
 
-          assert { cache[cache.last_accessed_key] == Marshal.dump(1) }
+          assert(cache[cache.last_accessed_key] == Marshal.dump(1))
         end
 
         it 'gets the marshalled value back' do
           cacher.set('foo') { 1 }
 
-          assert { cacher.get('foo') == 1 }
+          assert(cacher.get('foo') == 1)
         end
 
         it 'attempts to find missing constants' do
@@ -132,11 +132,11 @@ describe Cacher do
           end
 
           cacher.set('keepers') { Finders::Keepers.new }
-          assert { cacher.get('keepers').is_a? Finders::Keepers }
+          assert(cacher.get('keepers').is_a? Finders::Keepers)
           Finders.send :remove_const, 'Keepers'
-          assert { cacher.get('keepers').is_a? Finders::Keepers }
+          assert(cacher.get('keepers').is_a? Finders::Keepers)
           Object.send :remove_const, 'Finders'
-          assert { rescuing { cacher.get('keepers') }.is_a? NameError }
+          assert_raises(NameError){ cacher.get('keepers') }
         end
       end
     end
@@ -147,9 +147,9 @@ describe Cacher do
       end
 
       it 'nops when setting a key' do
-        assert { cacher.get('foo').nil? }
-        assert { cacher.set('foo') { 'bar' } == 'bar' }
-        assert { cacher.get('foo').nil? }
+        assert(cacher.get('foo').nil?)
+        assert(cacher.set('foo') { 'bar' } == 'bar')
+        assert(cacher.get('foo').nil?)
       end
     end
 
@@ -165,7 +165,7 @@ describe Cacher do
         cacher.get('foo') { 2 }
         cacher.unbust!
 
-        assert { cacher.get('foo') == 2 }
+        assert(cacher.get('foo') == 2)
       end
 
       it 'busts with a block' do
@@ -175,7 +175,7 @@ describe Cacher do
           cacher.get('foo') { 2 }
         end
 
-        assert { cacher.get('foo') == 2 }
+        assert(cacher.get('foo') == 2)
       end
     end
   end

--- a/spec/cacher_spec.rb
+++ b/spec/cacher_spec.rb
@@ -99,7 +99,7 @@ describe Cacher do
         assert(cacher.get(key) == 3)
       end
 
-      it 'get multiple values on a single request' do
+      it 'gets multiple values on a single request' do
         keys = ['foo', 'bar']
         assert(cacher.get_multi(keys) == [nil, nil])
         cacher.set(keys[0]) { 'a' }
@@ -107,7 +107,7 @@ describe Cacher do
         assert(cacher.get_multi(keys) == ['a', 'b'])
       end
 
-      it 'return nil value on a multiple requests for an inexistent value' do
+      it 'returns nil value on a multiple requests for an inexistent value' do
         keys = ['foo', 'bar', 'baz']
         assert(cacher.get_multi(keys) == [nil, nil, nil])
         cacher.set(keys[0]) { 'a' }

--- a/spec/cacher_spec.rb
+++ b/spec/cacher_spec.rb
@@ -99,6 +99,22 @@ describe Cacher do
         assert(cacher.get(key) == 3)
       end
 
+      it 'get multiple values on a single request' do
+        keys = ['foo', 'bar']
+        assert(cacher.get_multi(keys) == [nil, nil])
+        cacher.set(keys[0]) { 'a' }
+        cacher.set(keys[1]) { 'b' }
+        assert(cacher.get_multi(keys) == ['a', 'b'])
+      end
+
+      it 'return nil value on a multiple requests for an inexistent value' do
+        keys = ['foo', 'bar', 'baz']
+        assert(cacher.get_multi(keys) == [nil, nil, nil])
+        cacher.set(keys[0]) { 'a' }
+        cacher.set(keys[1]) { 'b' }
+        assert(cacher.get_multi(keys) == ['a', 'b', nil])
+      end
+
       describe 'marshalling' do
         before do
           cacher.marshal = true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,12 +6,6 @@ require 'cacher'
 require 'minitest/autorun'
 require 'minitest/spec'
 
-Wrong.config[:color] = true
-
-class MiniTest::Unit::TestCase
-  include Wrong
-end
-
 Dir[File.expand_path('support/**/*.rb', File.dirname(__FILE__))].each {|f|
   require f
 }

--- a/spec/support/test_cache.rb
+++ b/spec/support/test_cache.rb
@@ -20,6 +20,9 @@ class TestCache < Hash
     self[key.to_s] = val
   end
 
+  def read_multi(*keys)
+    self.select{|k, _| keys.include?(k) }
+end
 
 private
   def check_key(key)

--- a/spec/support/test_cache.rb
+++ b/spec/support/test_cache.rb
@@ -21,8 +21,8 @@ class TestCache < Hash
   end
 
   def read_multi(*keys)
-    self.select{|k, _| keys.include?(k) }
-end
+    self.select{ |k, _| keys.include?(k) }
+  end
 
 private
   def check_key(key)


### PR DESCRIPTION
* Fixing a bug, `cacher.read_multi` expect a set of parameters as input, not an array as was being passed by the `prepared_keys`variable.
* A minor refactor to make te code more readable